### PR TITLE
Fixed syntax highlighting for case and if

### DIFF
--- a/syntaxes/matlab.tmLanguage
+++ b/syntaxes/matlab.tmLanguage
@@ -239,7 +239,7 @@
 							</array>
 						</dict>
 						<dict>
-							<key>beginCaptures</key>
+							<key>captures</key>
 							<dict>
 								<key>0</key>
 								<dict>
@@ -270,7 +270,7 @@
 							<string>meta.elseif.matlab</string>
 						</dict>
 						<dict>
-							<key>beginCaptures</key>
+							<key>captures</key>
 							<dict>
 								<key>0</key>
 								<dict>
@@ -393,7 +393,7 @@
 							</array>
 						</dict>
 						<dict>
-							<key>beginCaptures</key>
+							<key>captures</key>
 							<dict>
 								<key>0</key>
 								<dict>
@@ -424,7 +424,7 @@
 							<string>meta.case.matlab</string>
 						</dict>
 						<dict>
-							<key>beginCaptures</key>
+							<key>captures</key>
 							<dict>
 								<key>0</key>
 								<dict>
@@ -476,7 +476,7 @@
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>beginCaptures</key>
+							<key>captures</key>
 							<dict>
 								<key>0</key>
 								<dict>


### PR DESCRIPTION
This was my quick and dirty fix for #9.  I'm not sure if this is the right way to handle it, but it seemed to work in my very limited test case.

Copying from my issue comment:

> Someone who knows what they are talking about should validate this, but I looked at if section of the converted textmate bundle from the Atom matlab language [here](https://github.com/JamesRitchie/language-matlab/blob/master/grammars/m.cson).
>
>The difference I noticed was the use of a 'captures' key vs a 'beginCaptures' key.  I have absolutely no idea what this means, so I swapped it blindly.