### PR TITLE
Fixed the console characters encoding issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,93 +1,96 @@
 {
-    "name": "matlab",
-    "displayName": "Matlab",
-    "description": "MATLAB support for Visual Studio Code",
-    "version": "0.7.0",
-    "publisher": "Gimly81",
-    "license": "SEE LICENSE IN LICENSE.md",
-    "engines": {
-        "vscode": "^1.16.0"
-    },
-    "categories": [
-        "Languages",
-        "Snippets",
-        "Linters"
+  "name": "matlab",
+  "displayName": "Matlab",
+  "description": "MATLAB support for Visual Studio Code",
+  "version": "0.7.0",
+  "publisher": "Gimly81",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "engines": {
+    "vscode": "^1.16.0"
+  },
+  "categories": [
+    "Languages",
+    "Snippets",
+    "Linters"
+  ],
+  "homepage": "https://github.com/Gimly/matlab-vscode/blob/master/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gimly/matlab-vscode.git"
+  },
+  "activationEvents": [
+    "onLanguage:matlab"
+  ],
+  "main": "./out/src/matlabMain",
+  "icon": "images/icon.png",
+  "bugs": "https://github.com/Gimly/matlab-vscode/issues",
+  "contributes": {
+    "languages": [
+      {
+        "id": "matlab",
+        "aliases": [
+          "MATLAB",
+          "matlab"
+        ],
+        "extensions": [
+          ".m"
+        ],
+        "configuration": "./matlab.configuration.json"
+      }
     ],
-    "homepage": "https://github.com/Gimly/matlab-vscode/blob/master/README.md",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gimly/matlab-vscode.git"
-    },
-    "activationEvents": [
-        "onLanguage:matlab"
+    "grammars": [
+      {
+        "language": "matlab",
+        "scopeName": "source.matlab",
+        "path": "./syntaxes/matlab.tmLanguage"
+      }
     ],
-    "main": "./out/src/matlabMain",
-    "icon": "images/icon.png",
-    "bugs": "https://github.com/Gimly/matlab-vscode/issues",
-    "contributes": {
-        "languages": [
-            {
-                "id": "matlab",
-                "aliases": [
-                    "MATLAB",
-                    "matlab"
-                ],
-                "extensions": [
-                    ".m"
-                ],
-                "configuration": "./matlab.configuration.json"
-            }
-        ],
-        "grammars": [
-            {
-                "language": "matlab",
-                "scopeName": "source.matlab",
-                "path": "./syntaxes/matlab.tmLanguage"
-            }
-        ],
-        "snippets": [
-            {
-                "language": "matlab",
-                "path": "./snippets/matlab.json"
-            }
-        ],
-        "configuration": {
-            "title": "Matlab configuration",
-            "type": "object",
-            "properties": {
-                "matlab.matlabpath": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The path to the matlab executable."
-                },
-                "matlab.mlintpath": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The path to the mlint executable"
-                },
-                "matlab.lintOnSave": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Run the linting on save of file."
-                },
-                "matlab.linterEncoding": {
-                    "type": "string",
-                    "default": "utf8",
-                    "description": "This sets the encoding for the linting, default is utf8. Use if your console uses a different encoding."
-                }
-            }
+    "snippets": [
+      {
+        "language": "matlab",
+        "path": "./snippets/matlab.json"
+      }
+    ],
+    "configuration": {
+      "title": "Matlab configuration",
+      "type": "object",
+      "properties": {
+        "matlab.matlabpath": {
+          "type": "string",
+          "default": null,
+          "description": "The path to the matlab executable."
+        },
+        "matlab.mlintpath": {
+          "type": "string",
+          "default": null,
+          "description": "The path to the mlint executable"
+        },
+        "matlab.lintOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run the linting on save of file."
+        },
+        "matlab.linterEncoding": {
+          "type": "string",
+          "default": "utf8",
+          "description": "This sets the encoding for the linting, default is utf8. Use if your console uses a different encoding."
         }
-    },
-    "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "typescript": "^2.5.2",
-        "vscode": "^1.1.5",
-        "mocha": "^3.5.0",
-        "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+      }
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "devDependencies": {
+    "typescript": "^2.5.2",
+    "vscode": "^1.1.5",
+    "mocha": "^3.5.0",
+    "@types/node": "^7.0.43",
+    "@types/mocha": "^2.2.42"
+  },
+  "dependencies": {
+    "iconv-lite": "^0.4.19"
+  }
 }

--- a/src/matlabDiagnostics.ts
+++ b/src/matlabDiagnostics.ts
@@ -3,6 +3,7 @@
 import vscode = require('vscode');
 import path = require('path');
 import cp = require('child_process');
+import iconv = require('iconv-lite');
 
 import { window } from 'vscode';
 
@@ -30,9 +31,9 @@ export function check(filename: string, lintOnSave = true, mlintPath = ""): Prom
 			mlintPath,
 			[filename],
 			{ encoding: 'buffer' },
-			(err : Error, stdout, stderr) => {
+			(err: Error, stdout, stderr) => {
 				try {
-					let errorsString = stderr.toString();
+					let errorsString = iconv.decode(stderr, fileEncoding);
 
 					var errors = errorsString.split('\n');
 


### PR DESCRIPTION
* Added iconv-lite as a dependency to be able to convert character encodings
* Used iconv-lite to convert the special character encodings used by matlab in non-english versions and add them as the linter

Fixes issue #16