### PR TITLE
Add integer tag to *printf syntax

### DIFF
--- a/syntaxes/matlab.tmLanguage
+++ b/syntaxes/matlab.tmLanguage
@@ -1742,7 +1742,7 @@
 							<key>comment</key>
 							<string>Operator symbols</string>
 							<key>match</key>
-							<string>((\%([\+\-0]?\d{0,3}(\.\d{1,3})?)(c|d|e|E|f|g|G|s|((b|t)?(o|u|x|X))))|\%\%|\\(b|f|n|r|t|\\))</string>
+							<string>((\%([\+\-0]?\d{0,3}(\.\d{1,3})?)(c|d|e|E|f|g|G|i|s|((b|t)?(o|u|x|X))))|\%\%|\\(b|f|n|r|t|\\))</string>
 							<key>name</key>
 							<string>constant.character.escape.matlab</string>
 						</dict>


### PR DESCRIPTION
Adds %i to the *printf syntax, which is the same as %d.