### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/matlabMain.ts
+++ b/src/matlabMain.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
 	
 	context.subscriptions.push(
 		vscode.languages.registerDocumentSymbolProvider(
-			'matlab', new MatlabDocumentSymbolProvider()
+			{ language: 'matlab', scheme: 'file' }, new MatlabDocumentSymbolProvider()
 		)
 	);
 


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for MATLAB, this PR simply updates the current `DocumentSelector` to be limited to local files. This way, when someone has the MATLAB extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*