### PR TITLE
Update endColumn value for mlint Diagnostic Range construction

### DIFF
--- a/src/matlabMain.ts
+++ b/src/matlabMain.ts
@@ -79,8 +79,7 @@ function lintDocument(document: vscode.TextDocument, mlintPath: string) {
 			var startColumn = error.column[0] - 1;
 			if (startColumn < 0) startColumn = 0;
 
-			var endColumn = error.column[1] - 1;
-			if (endColumn < 0) endColumn = 0;
+			var endColumn = error.column[1];
 
 			let range = new vscode.Range(line, startColumn, line, endColumn);
 			let diagnostic = new vscode.Diagnostic(range, error.msg, mapSeverityToVSCodeSeverity(error.severity));


### PR DESCRIPTION
See #54

Subtracting `1` from mlint's end column value results in an off-by-one error for underlining when passed to the [`Diagnostic`'s](https://code.visualstudio.com/docs/extensionAPI/vscode-api#Diagnostic) [`Range`](https://code.visualstudio.com/docs/extensionAPI/vscode-api#Range) constructor.

Before:

<img width="401" alt="current-behavior" src="https://user-images.githubusercontent.com/5323929/40681435-13f80efa-6357-11e8-9ba9-116b0bb7f56b.png">

After:

<img width="410" alt="updated-behavior" src="https://user-images.githubusercontent.com/5323929/40681448-1e32e318-6357-11e8-86c8-4fae9f02182b.png">

It's unclear whether or not this bug has always been present or if there was a change somewhere recently that introduced it. Based on this repo's current README, the bug was not present in earlier builds:

<img width="410" alt="README" src="https://raw.githubusercontent.com/Gimly/vscode-matlab/47f78333c7962367511b2be865116df34e232545/images/linter.png">

`nargchk` here is correctly highlighted. Nothing in this repo's history nor the vscode repo overtly indicate where this would have changed.

Perhaps it could be a change to mlint's return, but it seems consistent between at least R2018a and R2017a ([testing gist](https://gist.github.com/sco1/15ea4b5114404bbc4bcbf97ab38d7dfa)). If mlint has indeed changed then this PR would produce the same inconsistency, just for older version(s) instead.