### PR TITLE
MLINT issues

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -23,7 +23,7 @@
         ["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*\\b(function|if|else|elseif|switch|case|otherwise|for|parfor|while|try|catch|unwind_protect)\\b",
+		"increaseIndentPattern": "^\\s*\\b(function|if|else|elseif|switch|case|otherwise|for|parfor|while|try|catch|unwind_protect|properties|methods|enumeration|events)\\b",
 		"decreaseIndentPattern": "^\\s*\\b(end\\w*|catch|else|elseif|case|otherwise)\\b"
 	}
 }

--- a/src/matlabDiagnostics.ts
+++ b/src/matlabDiagnostics.ts
@@ -15,9 +15,9 @@ export interface ICheckResult {
 	severity: string
 }
 
-export function check(filename: string, lintOnSave = true, mlintPath = ""): Promise<ICheckResult[]> {
+export function check(document: vscode.TextDocument, lintOnSave = true, mlintPath = ""): Promise<ICheckResult[]> {
 	var matlabLint = !lintOnSave ? Promise.resolve([]) : new Promise((resolve, reject) => {
-		var filename = window.activeTextEditor.document.fileName;
+		var filename = document.uri.fsPath;
 
 		let matlabConfig = vscode.workspace.getConfiguration('matlab');
 

--- a/src/matlabMain.ts
+++ b/src/matlabMain.ts
@@ -47,6 +47,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(workspace.onDidSaveTextDocument(document => { lintDocument(document, mlintPath) }));
 	context.subscriptions.push(workspace.onDidOpenTextDocument(document => { lintDocument(document, mlintPath) }));
+
+	// Run mlint on any open documents since our onDidOpenTextDocument callback won't be hit for those
+	workspace.textDocuments.forEach(document => lintDocument(document, mlintPath));
 }
 
 function lintDocument(document: vscode.TextDocument, mlintPath: string) {
@@ -65,7 +68,7 @@ function lintDocument(document: vscode.TextDocument, mlintPath: string) {
 
 	let matlabConfig = vscode.workspace.getConfiguration('matlab');
 
-	check(document.uri.fsPath, matlabConfig['lintOnSave'], mlintPath).then(errors => {
+	check(document, matlabConfig['lintOnSave'], mlintPath).then(errors => {
 		diagnosticCollection.delete(document.uri);
 
 		let diagnosticMap: Map<vscode.Uri, vscode.Diagnostic[]> = new Map();;

--- a/src/matlabMain.ts
+++ b/src/matlabMain.ts
@@ -17,7 +17,7 @@ let diagnosticCollection: vscode.DiagnosticCollection;
 export function activate(context: vscode.ExtensionContext) {
 
 	console.log("Activating extension Matlab");
-	
+
 	context.subscriptions.push(
 		vscode.languages.registerDocumentSymbolProvider(
 			{ language: 'matlab', scheme: 'file' }, new MatlabDocumentSymbolProvider()
@@ -66,7 +66,7 @@ function lintDocument(document: vscode.TextDocument, mlintPath: string) {
 	let matlabConfig = vscode.workspace.getConfiguration('matlab');
 
 	check(document.uri.fsPath, matlabConfig['lintOnSave'], mlintPath).then(errors => {
-		diagnosticCollection.clear();
+		diagnosticCollection.delete(document.uri);
 
 		let diagnosticMap: Map<vscode.Uri, vscode.Diagnostic[]> = new Map();;
 


### PR DESCRIPTION
1. Address #66 with multiple files
1. Handle issues with onDidOpenTextDocument callback: Fix so opening a MATLAB file results in linting it, run MLINT on all opened files when the extension loads.
1. Addresses a possible cause for #24. We used to call `window.activeTextEditor.document.fileName` to get the file name to lint. If a save event occurs for a non-active MATLAB file, we may wind up running mlint on the active file instead.

Note that this builds on my fork used for https://github.com/Gimly/vscode-matlab/pull/83