### PR TITLE
Simplify symbol provider regex to improve performance.

### DIFF
--- a/src/documentSymbolProvider.ts
+++ b/src/documentSymbolProvider.ts
@@ -8,7 +8,7 @@ export class MatlabDocumentSymbolProvider implements vscode.DocumentSymbolProvid
         document: vscode.TextDocument,
         token: vscode.CancellationToken): vscode.SymbolInformation[] {
 
-        const _functionPattern = /function *(?:(?:(?:\[[ \w,]+\])|(?:\w+)) *= *)?(?:\w.?)+ *\(.*?\)/;
+        const _functionPattern = /^\s*function /;
 
         const result: vscode.SymbolInformation[] = [];
 
@@ -18,10 +18,10 @@ export class MatlabDocumentSymbolProvider implements vscode.DocumentSymbolProvid
             if (!text.startsWith("%") && _functionPattern.test(text)) {
                 result.push(
                     new vscode.SymbolInformation(
-                        text, 
+                        text.trim(),
                         vscode.SymbolKind.Function,
                         '',
-                        new vscode.Location(document.uri, new vscode.Position(line, 0))
+                        new vscode.Location(document.uri, new vscode.Range(line, 0, line, text.length - 1))
                     ));
             }
         }


### PR DESCRIPTION
 Fixes #81 and likely #82. Expand range of function to include entire line. Tested performance with the file provided by @Jamen1993 in https://github.com/Gimly/vscode-matlab/issues/81#issuecomment-505000082 and a few local files, classdef files, files from a MATLAB install.