### PR TITLE
Go to definition

### DIFF
--- a/src/PeekFileDefinitionProvider.ts
+++ b/src/PeekFileDefinitionProvider.ts
@@ -25,9 +25,10 @@ export default class PeekFileDefinitionProvider implements vscode.DefinitionProv
       const txtLine = doc.lineAt(lineNb);
       if (!txtLine.isEmptyOrWhitespace) {
         const content = txtLine.text;
-        const Col = content.indexOf('function ' + selectedText);
-        if (Col != -1) {
-          return [lineNb, Col];
+        const Colfunc = content.indexOf('function ');
+        const ColName = content.indexOf(selectedText);
+        if (Colfunc != -1 && ColName != -1) {
+          return [lineNb, Colfunc];
         }
       }
     }

--- a/src/PeekFileDefinitionProvider.ts
+++ b/src/PeekFileDefinitionProvider.ts
@@ -4,11 +4,8 @@ import vscode = require('vscode');
 import { isUndefined } from 'util';
 
 export default class PeekFileDefinitionProvider implements vscode.DefinitionProvider {
-  targetFileExtensions: string[] = [];
 
-  constructor(targetFileExtensions: string[] = []) {
-    this.targetFileExtensions = targetFileExtensions;
-  }
+  constructor() {}
 
   getComponentName(position: vscode.Position): String[] {
     const doc = vscode.window.activeTextEditor.document;

--- a/src/PeekFileDefinitionProvider.ts
+++ b/src/PeekFileDefinitionProvider.ts
@@ -1,0 +1,52 @@
+'use strict';
+
+import vscode = require('vscode');
+import { isUndefined } from 'util';
+
+export default class PeekFileDefinitionProvider implements vscode.DefinitionProvider {
+  targetFileExtensions: string[] = [];
+
+  constructor(targetFileExtensions: string[] = []) {
+    this.targetFileExtensions = targetFileExtensions;
+  }
+
+  getComponentName(position: vscode.Position): String[] {
+    const doc = vscode.window.activeTextEditor.document;
+    const selection = doc.getWordRangeAtPosition(position);
+    const selectedText = doc.getText(selection);
+    let possibleFileNames = [];
+    possibleFileNames.push(selectedText + '.m');
+    return possibleFileNames;
+  }
+
+  searchFilePath(fileName: String): Thenable<vscode.Uri[]> {
+    return vscode.workspace.findFiles(`**/${fileName}`, '**/node_modules'); // Returns promise
+  }
+
+  provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location | vscode.Location[]> {
+    
+    let filePaths = [];
+    const componentNames = this.getComponentName(position);
+    const searchPathActions = componentNames.map(this.searchFilePath);
+    const searchPromises = Promise.all(searchPathActions); // pass array of promises
+
+    return searchPromises.then((paths) => {
+      filePaths = [].concat.apply([], paths);
+      if (filePaths.length) {
+        let allPaths = [];
+        filePaths.forEach(filePath => {
+          allPaths.push(new vscode.Location(vscode.Uri.file(`${filePath.path}`),new vscode.Position(0,1) ))
+        });
+        return allPaths;
+      } else {
+        return undefined;
+      }
+    }, (reason) => {
+      return undefined;
+    });
+  }
+}

--- a/src/PeekFileDefinitionProvider.ts
+++ b/src/PeekFileDefinitionProvider.ts
@@ -26,8 +26,9 @@ export default class PeekFileDefinitionProvider implements vscode.DefinitionProv
       if (!txtLine.isEmptyOrWhitespace) {
         const content = txtLine.text;
         const Colfunc = content.indexOf('function ');
-        const ColName = content.indexOf(selectedText);
-        if (Colfunc != -1 && ColName != -1) {
+        const ColName1 = content.indexOf(selectedText + '(');
+        const ColName2 = content.indexOf(selectedText + ' (');
+        if (Colfunc != -1 && (ColName1 != -1 || ColName2 != -1)) {
           return [lineNb, Colfunc];
         }
       }

--- a/src/matlabMain.ts
+++ b/src/matlabMain.ts
@@ -8,6 +8,7 @@ import { check, ICheckResult } from './matlabDiagnostics';
 
 import { commands, window, workspace, InputBoxOptions } from 'vscode';
 import { MatlabDocumentSymbolProvider } from './documentSymbolProvider';
+import PeekFileDefinitionProvider from './PeekFileDefinitionProvider';
 
 var canLint = true;
 let diagnosticCollection: vscode.DiagnosticCollection;
@@ -50,6 +51,12 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Run mlint on any open documents since our onDidOpenTextDocument callback won't be hit for those
 	workspace.textDocuments.forEach(document => lintDocument(document, mlintPath));
+
+	context.subscriptions.push(vscode.languages.registerDefinitionProvider(
+    ['matlab'],
+    new PeekFileDefinitionProvider(['.m'])
+  ));
+
 }
 
 function lintDocument(document: vscode.TextDocument, mlintPath: string) {

--- a/src/matlabMain.ts
+++ b/src/matlabMain.ts
@@ -54,7 +54,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.languages.registerDefinitionProvider(
     ['matlab'],
-    new PeekFileDefinitionProvider(['.m'])
+    new PeekFileDefinitionProvider()
   ));
 
 }


### PR DESCRIPTION
Hello, 

here is a first proposition for the peek and go to definition feature that I missed too much from the matlab native ide.

It works well for different files but doesn't work for nested functions. I tried my best, but since I don't know how to create Promise I could not add this feature.

It is almost a direct copy from the vue peek extension.

Best regards!

Robin
