### PR TITLE
Add folding with %%

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -22,6 +22,12 @@
         ["\"", "\""],
         ["'", "'"]
 	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*%%",
+			"end": "^\\s*%%"
+		}
+	},
 	"indentationRules": {
 		"increaseIndentPattern": "^\\s*\\b(function|if|else|elseif|switch|case|otherwise|for|parfor|while|try|catch|unwind_protect|properties|methods|enumeration|events|arguments)\\b",
 		"decreaseIndentPattern": "^\\s*\\b(end\\w*|catch|else|elseif|case|otherwise)\\b"


### PR DESCRIPTION
Part of the issue  #114 asks for a support of folding for %%.

I'm not sure this will work 100% as VS Code asks for a begin and end of the folding, which Matlab doesn't seem to have.

We'll see how this is accepted.