### PR TITLE
remove the line break on block comment setting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,7 @@
 {
 	"comments": {
 		"lineComment": "%",
-		"blockComment": [ "\n%{\n", "\n%}\n" ]
+		"blockComment": [ "%{", "%}" ]
 	},
 	"brackets": [
 		["{", "}"],


### PR DESCRIPTION
I installed the matlab v2.0.0 on my vscode.   
If I toggle a block of code into command, that works. But when I try to toggle the block of comment back to code, it failed. It just wraps another `%{  %}` on it.
original
![image](https://user-images.githubusercontent.com/38422065/98871037-3fb1f200-2442-11eb-8e2b-64d3d1f92ad0.png)
first `ctrl+alt+a`
![image](https://user-images.githubusercontent.com/38422065/98871060-4a6c8700-2442-11eb-95c4-45b3ce58aa39.png)
second `ctrl+alt+a`
![image](https://user-images.githubusercontent.com/38422065/98871098-5ce6c080-2442-11eb-95eb-3c5206e608d6.png)
