### PR TITLE
Add GitHub actions to automate deployment

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+    - created
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - run: npm install
+    - run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - run: npm test
+      if: runner.os != 'Linux'
+    - name: Publish
+      if: success() && startsWith( github.ref, 'refs/tags/releases/') && matrix.os == 'ubuntu-latest'
+      run: npm run deploy
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/package.json
+++ b/package.json
@@ -118,12 +118,14 @@
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
-    "compile": "tsc -watch -p ./"
+    "compile": "tsc -watch -p ./",
+    "deploy": "vsce publish --yarn"
   },
   "devDependencies": {
     "@types/node": "^7.0.43",
     "@types/vscode": "^1.57.1",
     "typescript": "^4.3.5",
+    "vsce": "^1.100.1",
     "vscode-test": "^1.5.2"
   },
   "dependencies": {


### PR DESCRIPTION
To simplify the deployment of new version, this adds a GitHub Actions script that will automatically build and deploy the version on tags.