### PR TITLE
Remove node_modules from .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,4 +8,3 @@ src/**
 tsconfig.json
 vsc-extension-quickstart.md
 *.vsix
-node_modules/**


### PR DESCRIPTION
The node_modules was incorrectly added to the .vscodeignore which might have caused the missing dependencies which made the plugin fail to load correctly.

Should fix #140 #141 