### PR TITLE
Update `vscode-textmate-languageservice` from 0.1.1 to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.3.0]
+
+- Updates the Matlab syntax, for extended function definition syntax and superclass method `@` operator.
+- Update the VS Code Textmate service API to the latest version with multiple bugfixes and optimisations.
+
+## [2.2.1]
+
+- Remove `node_modules` from `.vscodeignore`.
+- Add a GitHub Actions to automate the deployment.
+
 ## [2.1.0]
 
 - Add injection grammars for packages, validation and overloads

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     }
   },
   "scripts": {
+    "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "matlab",
   "displayName": "Matlab",
   "description": "MATLAB support for Visual Studio Code",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "publisher": "Gimly81",
   "license": "MIT",
   "engines": {
@@ -117,7 +117,6 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
@@ -125,6 +124,7 @@
     "deploy": "vsce publish --yarn"
   },
   "devDependencies": {
+    "@types/node": "^16.10.2",
     "@types/vscode": "^1.57.1",
     "esbuild": "^0.13.4",
     "typescript": "^4.3.5",
@@ -132,12 +132,7 @@
     "vscode-test": "^1.5.2"
   },
   "dependencies": {
-    "@types/node": "^16.10.2",
-    "escape-string-regexp": "^5.0.0",
     "iconv-lite": "^0.6.3",
-    "vscode-oniguruma": "^1.5.1",
-    "vscode-test": "^1.5.2",
-    "vscode-textmate": "^5.4.0",
-    "vscode-textmate-languageservice": "^0.1.0"
+    "vscode-textmate-languageservice": "^0.2.0"
   }
 }

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -17,86 +17,86 @@
     "path": "./syntaxes/MATLAB-Language-grammar/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage"
   },
   "assignment": {
-    "separator": "punctuation.separator.comma.matlab - meta.parens.matlab",
-    "single": "meta.assignment.variable.single.matlab",
-    "multiple": "meta.assignment.variable.group.matlab"
+    "separator": "punctuation.separator.comma - meta.parens",
+    "single": "meta.assignment.variable.single",
+    "multiple": "meta.assignment.variable.group"
   },
   "comments": {
-    "lineComment": "comment.line.percentage.matlab",
+    "lineComment": "comment.line.percentage",
     "blockComment": [
-      "punctuation.definition.comment.begin.matlab",
-      "punctuation.definition.comment.end.matlab"
+      "punctuation.definition.comment.begin",
+      "punctuation.definition.comment.end"
     ]
   },
   "declarations": [
     "meta.declaration entity.name",
     "meta.assignment.definition entity.name",
-    "comment.line.double-percentage entity.name.section.matlab"
+    "comment.line.double-percentage entity.name.section"
   ],
   "dedentation": [
-    "keyword.control.elseif.matlab",
-    "keyword.control.else.matlab"
+    "keyword.control.elseif",
+    "keyword.control.else"
   ],
   "exclude": "**/{external,mpm-packages}/**",
   "indentation": {
-    "punctuation.definition.comment.begin.matlab": 1,
-    "punctuation.definition.comment.end.matlab": -1,
-    "keyword.control.for.matlab": 1,
-    "keyword.control.end.for.matlab": -1,
-    "keyword.control.if.matlab": 1,
-    "keyword.control.end.if.matlab": -1,
-    "keyword.control.else.matlab": -1,
-    "keyword.control.elseif.matlab": -1,
-    "keyword.control.repeat.parallel.matlab": 1,
-    "keyword.control.end.repeat.parallel.matlab": -1,
-    "keyword.control.switch.matlab": 1,
-    "keyword.control.end.switch.matlab": -1,
-    "keyword.control.try.matlab": 1,
-    "keyword.control.end.try.matlab": -1,
-    "keyword.control.while.matlab": 1,
-    "keyword.control.end.while.matlab": -1,
-    "storage.type.class.matlab": 1,
-    "storage.type.class.end.matlab": -1,
-    "keyword.control.enum.matlab": 1,
-    "keyword.control.end.enum.matlab": -1,
-    "keyword.control.events.matlab": 1,
-    "keyword.control.end.events.matlab": -1,
-    "keyword.control.methods.matlab": 1,
-    "keyword.control.end.methods.matlab": -1,
-    "keyword.control.properties.matlab": 1,
-    "keyword.control.end.properties.matlab": -1,
-    "storage.type.function.matlab": 1,
-    "storage.type.function.end.matlab": -1,
-    "keyword.control.arguments.matlab": 1,
-    "keyword.control.end.arguments.matlab": -1
+    "punctuation.definition.comment.begin": 1,
+    "punctuation.definition.comment.end": -1,
+    "keyword.control.for": 1,
+    "keyword.control.end.for": -1,
+    "keyword.control.if": 1,
+    "keyword.control.end.if": -1,
+    "keyword.control.else": -1,
+    "keyword.control.elseif": -1,
+    "keyword.control.repeat.parallel": 1,
+    "keyword.control.end.repeat.parallel": -1,
+    "keyword.control.switch": 1,
+    "keyword.control.end.switch": -1,
+    "keyword.control.try": 1,
+    "keyword.control.end.try": -1,
+    "keyword.control.while": 1,
+    "keyword.control.end.while": -1,
+    "storage.type.class": 1,
+    "storage.type.class.end": -1,
+    "keyword.control.enum": 1,
+    "keyword.control.end.enum": -1,
+    "keyword.control.events": 1,
+    "keyword.control.end.events": -1,
+    "keyword.control.methods": 1,
+    "keyword.control.end.methods": -1,
+    "keyword.control.properties": 1,
+    "keyword.control.end.properties": -1,
+    "storage.type.function": 1,
+    "storage.type.function.end": -1,
+    "keyword.control.arguments": 1,
+    "keyword.control.end.arguments": -1
   },
   "punctuation": {
-    "continuation": "punctuation.separator.continuation.line.matlab"
+    "continuation": "punctuation.separator.continuation.line"
   },
   "markers": {
     "start": "^\\s*#?region\\b",
     "end": "^\\s*#?end\\s?region\\b"
   },
   "symbols": {
-    "meta.for.matlab keyword.control.for.matlab": 2,
-    "meta.if.matlab keyword.control.if.matlab": 2,
-    "meta.else.matlab keyword.control.else.matlab": 2,
-    "meta.elseif.matlab keyword.control.elseif.matlab": 2,
-    "meta.repeat.parallel.matlab keyword.control.repeat.parallel.matlab": 2,
-    "meta.switch.matlab keyword.control.switch.matlab": 2,
-    "meta.try.matlab keyword.control.try.matlab": 2,
-    "meta.while.matlab keyword.control.while.matlab": 2,
-    "meta.class.matlab entity.name.type.class.matlab": 4,
-    "meta.enum.matlab variable.other.enummember.matlab": 21,
-    "meta.events.matlab entity.name.type.event.matlab": 23,
-    "meta.enum.matlab keyword.control.enum.matlab": 2,
-    "meta.events.matlab keyword.control.events.matlab": 2,
-    "meta.methods.matlab keyword.control.methods.matlab": 2,
-    "meta.properties.matlab keyword.control.properties.matlab": 2,
-    "meta.function.declaration.matlab entity.name.function.matlab": 11,
-    "meta.assignment.definition.property.matlab variable.object.property.matlab": 6,
-    "comment.line.double-percentage.matlab entity.name.section.matlab": 14,
-    "meta.assignment.variable.single.matlab": 12,
-    "meta.assignment.variable.group.matlab": 12
+    "meta.for keyword.control.for": 2,
+    "meta.if keyword.control.if": 2,
+    "meta.else keyword.control.else": 2,
+    "meta.elseif keyword.control.elseif": 2,
+    "meta.repeat.parallel keyword.control.repeat.parallel": 2,
+    "meta.switch keyword.control.switch": 2,
+    "meta.try keyword.control.try": 2,
+    "meta.while keyword.control.while": 2,
+    "meta.class entity.name.type.class": 4,
+    "meta.enum variable.other.enummember": 21,
+    "meta.events entity.name.type.event": 23,
+    "meta.enum keyword.control.enum": 2,
+    "meta.events keyword.control.events": 2,
+    "meta.methods keyword.control.methods": 2,
+    "meta.properties keyword.control.properties": 2,
+    "meta.function.declaration entity.name.function": 11,
+    "meta.assignment.definition.property variable.object.property": 6,
+    "comment.line.double-percentage entity.name.section": 14,
+    "meta.assignment.variable.single": 12,
+    "meta.assignment.variable.group": 12
   }
 }

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -17,15 +17,15 @@
     "path": "./syntaxes/MATLAB-Language-grammar/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage"
   },
   "assignment": {
-    "separator": "punctuation.separator.comma - meta.parens",
-    "single": "meta.assignment.variable.single",
-    "multiple": "meta.assignment.variable.group"
+    "separator": "punctuation.separator.comma.matlab - meta.parens",
+    "single": "meta.assignment.variable.single.matlab",
+    "multiple": "meta.assignment.variable.group.matlab"
   },
   "comments": {
-    "lineComment": "comment.line.percentage",
+    "lineComment": "comment.line.percentage.matlab",
     "blockComment": [
-      "punctuation.definition.comment.begin",
-      "punctuation.definition.comment.end"
+      "punctuation.definition.comment.begin.matlab",
+      "punctuation.definition.comment.end.matlab"
     ]
   },
   "declarations": [
@@ -39,36 +39,36 @@
   ],
   "exclude": "**/{external,mpm-packages}/**",
   "indentation": {
-    "punctuation.definition.comment.begin": 1,
-    "punctuation.definition.comment.end": -1,
-    "keyword.control.for": 1,
-    "keyword.control.end.for": -1,
-    "keyword.control.if": 1,
-    "keyword.control.end.if": -1,
-    "keyword.control.else": -1,
-    "keyword.control.elseif": -1,
-    "keyword.control.repeat.parallel": 1,
-    "keyword.control.end.repeat.parallel": -1,
-    "keyword.control.switch": 1,
-    "keyword.control.end.switch": -1,
-    "keyword.control.try": 1,
-    "keyword.control.end.try": -1,
-    "keyword.control.while": 1,
-    "keyword.control.end.while": -1,
-    "storage.type.class": 1,
-    "storage.type.class.end": -1,
-    "keyword.control.enum": 1,
-    "keyword.control.end.enum": -1,
-    "keyword.control.events": 1,
-    "keyword.control.end.events": -1,
-    "keyword.control.methods": 1,
-    "keyword.control.end.methods": -1,
-    "keyword.control.properties": 1,
-    "keyword.control.end.properties": -1,
-    "storage.type.function": 1,
-    "storage.type.function.end": -1,
-    "keyword.control.arguments": 1,
-    "keyword.control.end.arguments": -1
+    "punctuation.definition.comment.begin.matlab": 1,
+    "punctuation.definition.comment.end.matlab": -1,
+    "keyword.control.for.matlab": 1,
+    "keyword.control.end.for.matlab": -1,
+    "keyword.control.if.matlab": 1,
+    "keyword.control.end.if.matlab": -1,
+    "keyword.control.else.matlab": -1,
+    "keyword.control.elseif.matlab": -1,
+    "keyword.control.repeat.parallel.matlab": 1,
+    "keyword.control.end.repeat.parallel.matlab": -1,
+    "keyword.control.switch.matlab": 1,
+    "keyword.control.end.switch.matlab": -1,
+    "keyword.control.try.matlab": 1,
+    "keyword.control.end.try.matlab": -1,
+    "keyword.control.while.matlab": 1,
+    "keyword.control.end.while.matlab": -1,
+    "storage.type.class.matlab": 1,
+    "storage.type.class.end.matlab": -1,
+    "keyword.control.enum.matlab": 1,
+    "keyword.control.end.enum.matlab": -1,
+    "keyword.control.events.matlab": 1,
+    "keyword.control.end.events.matlab": -1,
+    "keyword.control.methods.matlab": 1,
+    "keyword.control.end.methods.matlab": -1,
+    "keyword.control.properties.matlab": 1,
+    "keyword.control.end.properties.matlab": -1,
+    "storage.type.function.matlab": 1,
+    "storage.type.function.end.matlab": -1,
+    "keyword.control.arguments.matlab": 1,
+    "keyword.control.end.arguments.matlab": -1
   },
   "punctuation": {
     "continuation": "punctuation.separator.continuation.line"

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -17,7 +17,7 @@
     "path": "./syntaxes/MATLAB-Language-grammar/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage"
   },
   "assignment": {
-    "separator": "punctuation.separator.comma.matlab - meta.parens",
+    "separator": "punctuation.separator.comma.matlab - parens",
     "single": "meta.assignment.variable.single.matlab",
     "multiple": "meta.assignment.variable.group.matlab"
   },

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -29,7 +29,7 @@
     ]
   },
   "declarations": [
-    "meta.declaration entity.name",
+    "meta.*.declaration entity.name",
     "meta.assignment.definition entity.name",
     "comment.line.double-percentage entity.name.section"
   ],

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -17,7 +17,7 @@
     "path": "./syntaxes/MATLAB-Language-grammar/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage"
   },
   "assignment": {
-    "separator": "punctuation.separator.comma.matlab",
+    "separator": "punctuation.separator.comma.matlab - meta.parens.matlab",
     "single": "meta.assignment.variable.single.matlab",
     "multiple": "meta.assignment.variable.group.matlab"
   },
@@ -29,9 +29,9 @@
     ]
   },
   "declarations": [
-    " meta\\.([\\w-]+)\\.declaration\\.matlab entity\\.name(\\.type)?\\.\\1",
-    " meta\\.assignment\\.definition\\.([\\w-]+)\\.matlab entity\\.name(\\.type)?\\.\\1",
-    " comment\\.line\\.double-percentage\\.matlab entity\\.name\\.section\\.matlab$"    
+    "meta.declaration.matlab entity.name",
+    "meta.assignment.definition.matlab entity.name",
+    "comment.line.double-percentage.matlab entity.name.section.matlab"
   ],
   "dedentation": [
     "keyword.control.elseif.matlab",
@@ -78,24 +78,24 @@
     "end": "^\\s*#?end\\s?region\\b"
   },
   "symbols": {
-    "keyword.control.for.matlab": 2,
-    "keyword.control.if.matlab": 2,
-    "keyword.control.else.matlab": 2,
-    "keyword.control.elseif.matlab": 2,
-    "keyword.control.repeat.parallel.matlab": 2,
-    "keyword.control.switch.matlab": 2,
-    "keyword.control.try.matlab": 2,
-    "keyword.control.while.matlab": 2,
-    "entity.name.type.class.matlab": 4,
-    "variable.other.enummember.matlab": 21,
-    "entity.name.type.event.matlab": 23,
-    "keyword.control.enum.matlab": 2,
-    "keyword.control.events.matlab": 2,
-    "keyword.control.methods.matlab": 2,
-    "keyword.control.properties.matlab": 2,
-    "entity.name.function.matlab": 11,
-    "variable.object.property.matlab": 6,
-    "entity.name.section.matlab": 14,
+    "meta.for.matlab keyword.control.for.matlab": 2,
+    "meta.if.matlab keyword.control.if.matlab": 2,
+    "meta.else.matlab keyword.control.else.matlab": 2,
+    "meta.elseif.matlab keyword.control.elseif.matlab": 2,
+    "meta.repeat.parallel.matlab keyword.control.repeat.parallel.matlab": 2,
+    "meta.switch.matlab keyword.control.switch.matlab": 2,
+    "meta.try.matlab keyword.control.try.matlab": 2,
+    "meta.while.matlab keyword.control.while.matlab": 2,
+    "meta.class.matlab entity.name.type.class.matlab": 4,
+    "meta.enum.matlab variable.other.enummember.matlab": 21,
+    "meta.events.matlab entity.name.type.event.matlab": 23,
+    "meta.enum.matlab keyword.control.enum.matlab": 2,
+    "meta.events.matlab keyword.control.events.matlab": 2,
+    "meta.methods.matlab keyword.control.methods.matlab": 2,
+    "meta.properties.matlab keyword.control.properties.matlab": 2,
+    "meta.function.declaration.matlab entity.name.function.matlab": 11,
+    "meta.assignment.definition.property.matlab variable.object.property.matlab": 6,
+    "comment.line.double-percentage.matlab entity.name.section.matlab": 14,
     "meta.assignment.variable.single.matlab": 12,
     "meta.assignment.variable.group.matlab": 12
   }

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -29,9 +29,9 @@
     ]
   },
   "declarations": [
-    "meta.declaration.matlab entity.name",
-    "meta.assignment.definition.matlab entity.name",
-    "comment.line.double-percentage.matlab entity.name.section.matlab"
+    "meta.declaration entity.name",
+    "meta.assignment.definition entity.name",
+    "comment.line.double-percentage entity.name.section.matlab"
   ],
   "dedentation": [
     "keyword.control.elseif.matlab",

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -96,7 +96,7 @@
     "meta.function.declaration entity.name.function": 11,
     "meta.assignment.definition.property variable.object.property": 6,
     "comment.line.double-percentage entity.name.section": 14,
-    "meta.assignment.variable.single": 12,
-    "meta.assignment.variable.group": 12
+    "meta.assignment.variable.single variable.other.readwrite": 12,
+    "meta.assignment.variable.group variable.other.readwrite": 12
   }
 }


### PR DESCRIPTION
Closes #140, closes #141, closes #142, closes #143, closes #145, closes #147.

Changelog:

- Update grammar with extended function definition syntax and superclass method `@` operator.
- Update Textmate service API with optimisations, bugfixes and Atom's Textmate scope parser.

Tasks:

  - [x] Cannot use linter - #140.
  - [x] Cannot use "Peek Definition" - #140.
  - [x] "No symbols found" in Outline pane - #141.
  - [x] Freezes and remains uneditable on opening a large file - #142.
  - [x] ~~Slowdown on large files~~ - #142. (stretch goal 💪🏾, shelved in this release)
  - [x] CTRL-Click to open function definition does not work - #143. 
  - [x] Snippets and Code Checking is not working - #145.
  - [x] Go to Definition is not working - #146. (duplicate)

N.B: Major change - `meta.parens` does not match `meta.function-call.parens` in Textmate scope selectors.