### PR TITLE
Fix `2.3.0` perf regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/Gimly/matlab-vscode.git"
   },
   "activationEvents": [
-    "onLanguage:matlab"
+    "onLanguage:matlab",
+    "onLanguage:markdown"
   ],
   "main": "./out/src/extension",
   "icon": "images/icon.png",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,6 @@
   },
   "dependencies": {
     "iconv-lite": "^0.6.3",
-    "vscode-textmate-languageservice": "^0.2.0"
+    "vscode-textmate-languageservice": "^0.2.1"
   }
 }

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -29,8 +29,8 @@
     ]
   },
   "declarations": [
-    "meta.*.declaration entity.name",
-    "meta.assignment.definition entity.name",
+    "declaration entity.name",
+    "assignment.definition entity.name",
     "comment.line.double-percentage entity.name.section"
   ],
   "dedentation": [

--- a/textmate-configuration.json
+++ b/textmate-configuration.json
@@ -29,8 +29,8 @@
     ]
   },
   "declarations": [
-    "declaration entity.name",
-    "assignment.definition entity.name",
+    "meta.*.declaration entity.name",
+    "meta.assignment.definition entity.name",
     "comment.line.double-percentage entity.name.section"
   ],
   "dedentation": [


### PR DESCRIPTION
Resolves #152.
Resolves #153.

`0.2.1` of the Textmate-based LSP adds caching layers for TM scope parsing to fix the performance.
My Windows 7 two-core crap-tuper loves it, and tests took 47s to run instead of 70s!

PS: I've noticed that the compiled extension has old files in `out/src` so they need cleaning!