### PR TITLE
Bump vscode-textmate-languageservice from 0.2.1 to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,6 @@
   },
   "dependencies": {
     "iconv-lite": "^0.6.3",
-    "vscode-textmate-languageservice": "^0.2.1"
+    "vscode-textmate-languageservice": "^0.2.2"
   }
 }


### PR DESCRIPTION
Closes #157. Addresses severe performance issues in folding provider block dedentation.